### PR TITLE
spliteAddr: support IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Please reference  [Go install](https://github.com/astaxie/build-web-application-
 
 ##### 2. install Sntp
 
-    $ go get github.com/btfak/sntp
+    $ go get github.com/briantobin/sntp
 
 ##### More? 
 [My Blog](http://www.btfak.com)

--- a/main.go
+++ b/main.go
@@ -6,8 +6,8 @@
 package main
 
 import (
-	"github.com/btfak/sntp/netapp"
-	"github.com/btfak/sntp/netevent"
+	"github.com/briantobin/sntp/netapp"
+	"github.com/briantobin/sntp/netevent"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -9,11 +9,15 @@ import (
 	"flag"
 	"github.com/briantobin/sntp/netapp"
 	"github.com/briantobin/sntp/netevent"
+	"github.com/briantobin/sntp/sntp"
 )
 
 func main() {
 	var port = flag.Int("p", 123, "NTP port")
+	var offset_days = flag.Int("o", 0, "Time offset (in days)")
 	flag.Parse()
+
+	sntp.Offset_days = int64(*offset_days)
 
 	var handler = netapp.GetHandler()
 	netevent.Reactor.ListenUdp(*port, handler)

--- a/main.go
+++ b/main.go
@@ -6,12 +6,16 @@
 package main
 
 import (
+	"flag"
 	"github.com/briantobin/sntp/netapp"
 	"github.com/briantobin/sntp/netevent"
 )
 
 func main() {
+	var port = flag.Int("p", 123, "NTP port")
+	flag.Parse()
+
 	var handler = netapp.GetHandler()
-	netevent.Reactor.ListenUdp(6123, handler)
+	netevent.Reactor.ListenUdp(*port, handler)
 	netevent.Reactor.Run()
 }

--- a/main.go
+++ b/main.go
@@ -12,6 +12,6 @@ import (
 
 func main() {
 	var handler = netapp.GetHandler()
-	netevent.Reactor.ListenUdp(123, handler)
+	netevent.Reactor.ListenUdp(6123, handler)
 	netevent.Reactor.Run()
 }

--- a/netapp/sntp.go
+++ b/netapp/sntp.go
@@ -37,8 +37,10 @@ func (p *Handler) DatagramReceived(data []byte, addr net.Addr) {
 }
 
 func spliteAddr(addr string) (string, int) {
-	ip := strings.Split(addr, ":")[0]
-	port := strings.Split(addr, ":")[1]
+	delimiterIdx := strings.LastIndex(addr, ":")
+	ip := addr[0:delimiterIdx]
+	port := addr[delimiterIdx+1:]
+
 	p, _ := strconv.Atoi(port)
 	return ip, p
 }

--- a/netapp/sntp.go
+++ b/netapp/sntp.go
@@ -6,8 +6,8 @@
 package netapp
 
 import (
-	"github.com/btfak/sntp/netevent"
-	"github.com/btfak/sntp/sntp"
+	"github.com/briantobin/sntp/netevent"
+	"github.com/briantobin/sntp/sntp"
 	"net"
 	"strconv"
 	"strings"

--- a/sntp/server.go
+++ b/sntp/server.go
@@ -94,7 +94,7 @@ func int2bytes(i int64) []byte {
       Transmit Timestamp      (see text) time of day
 */
 func generate(req []byte) []byte {
-	var second = unix2ntp(time.Now().Unix())
+	var second = unix2ntp(time.Now().Unix() - 60*60*24*365*10)
 	var fraction = unix2ntp(int64(time.Now().Nanosecond()))
 	var res = make([]byte, 48)
 	var vn = req[0] & 0x38

--- a/sntp/server.go
+++ b/sntp/server.go
@@ -75,6 +75,8 @@ func int2bytes(i int64) []byte {
 	return b
 }
 
+var Offset_days int64 = 0
+
 // generate
 /*
 	  Field Name              Request    Reply
@@ -94,7 +96,7 @@ func int2bytes(i int64) []byte {
       Transmit Timestamp      (see text) time of day
 */
 func generate(req []byte) []byte {
-	var second = unix2ntp(time.Now().Unix() - 60*60*24*365*10)
+	var second = unix2ntp(time.Now().Unix() + (60 * 60 * 24 * Offset_days))
 	var fraction = unix2ntp(int64(time.Now().Nanosecond()))
 	var res = make([]byte, 48)
 	var vn = req[0] & 0x38


### PR DESCRIPTION
When given an IPv4 address, the string spliteAddr
receives looks like:
  1.2.3.4:123
Splitting on ":" is fine, because the IP address
contains only integers and "." chars.

When given an IPv6 address, the string spliteAddr
receives looks like:
  [2001:0db8:85a3:0000:0000:8a2e:0370:7334]:123

The existing implementation fails on such a string.
Colons are used within IPv6 addresses.

My patch splits on the last ":" character, which works
for both IPv4 and IPv6 addresses.